### PR TITLE
dist binary without debugging information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           for GOOS in ${{ matrix.goos }}; do
             for GOARCH in ${{ matrix.goarch }}; do
               PACKAGE_NAME="fds-${GOOS}-${GOARCH}.tar.gz"
-              env GOOS=$GOOS GOARCH=$GOARCH go build -o dist/fds ./cmd
+              env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags "-w -s" -o dist/fds ./cmd
               tar czf dist/${PACKAGE_NAME} -C dist/ fds
               rm dist/fds
             done


### PR DESCRIPTION
Hello @gabrieloliverio 

The distributed binary contains debug info and it is not stripped as we can see:

```
$ file /usr/local/bin/fds
/usr/local/bin/fds: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=8e2f056751d2fcc847dece4c4ec62455c79bafe6, with debug_info, not stripped
```

You could distribute it smaller. The GNU/Linux binary for amd64 currently is 3.4MB and with this small change it can be dropped to 2.2MB. 